### PR TITLE
Add configuration to apply the AuthorizeAttribute globally

### DIFF
--- a/ApiGateway/ApiGateway.fsproj
+++ b/ApiGateway/ApiGateway.fsproj
@@ -47,7 +47,8 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Bristech.Srm.HttpConfig">
-      <HintPath>..\packages\Bristech.Srm.HttpConfig.0.1.4\lib\net45\Bristech.Srm.HttpConfig.dll</HintPath>
+      <HintPath>..\packages\Bristech.Srm.HttpConfig.0.1.5.0\lib\net45\Bristech.Srm.HttpConfig.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="FSharp.Core">
       <HintPath>..\packages\FSharp.Core.4.0.0.1\lib\net40\FSharp.Core.dll</HintPath>

--- a/ApiGateway/Program.fs
+++ b/ApiGateway/Program.fs
@@ -1,9 +1,10 @@
-module Program
-
-open Microsoft.Owin.Hosting
-open System.Threading
+open Bristech.Srm.HttpConfig
 open Logging
+open Microsoft.Owin.Hosting
+open Owin
 open Serilog
+open StartupConfig
+open System.Threading
 
 (*
     Note: When running this app from Visual studio / On Windows / Possibly with mono develop (Not checked)
@@ -18,19 +19,21 @@ open Serilog
     Reference : http://stackoverflow.com/questions/27842979/owin-webapp-start-gives-a-first-chance-exception-of-type-system-reflection-targ 
 *)
 [<EntryPoint>]
-let main _ =
+let main _ = 
     setupLogging()
-
     let baseAddress = "http://*:9004"
-    use server = WebApp.Start<Bristech.Srm.HttpConfig.Startup>(baseAddress)
+    
+    use server = 
+        WebApp.Start(baseAddress, 
+                     (fun appBuilder -> 
+                     let config = Default.config //|> configureFilters
+                     appBuilder.UseWebApi(config) |> ignore))
     Log.Information("Listening on {Address}", baseAddress)
-
     (*
         Because of the way the self hosted server works, it is waiting asynchronously for requests. 
         It starts running then returns to our code, meaning our program will exit. 
         This code will wait indefinitely for a signal so that the overall project will continue to run.
     *)
-    
     let waitIndefinitelyWithToken = 
         let cancelSource = new CancellationTokenSource()
         cancelSource.Token.WaitHandle.WaitOne() |> ignore

--- a/ApiGateway/StartupConfig.fs
+++ b/ApiGateway/StartupConfig.fs
@@ -1,0 +1,7 @@
+﻿module StartupConfig
+
+open System.Web.Http
+
+let configureFilters (config : HttpConfiguration) = 
+    config.Filters.Add(new AuthorizeAttribute())
+    config

--- a/ApiGateway/packages.config
+++ b/ApiGateway/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Bristech.Srm.HttpConfig" version="0.1.4.0" targetFramework="net45" />
+  <package id="Bristech.Srm.HttpConfig" version="0.1.5.0" targetFramework="net45" />
   <package id="FSharp.Core" version="4.0.0.1" targetFramework="net45" />
   <package id="Microsoft.AspNet.Cors" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi" version="5.2.3" targetFramework="net45" />


### PR DESCRIPTION
Configuration code has been added, but not applied.
Configuration will be applied when the dependent Authorization tasks are complete.

To test the code, uncomment the second half of line 9, and attempt to hit one of the controller methods. 